### PR TITLE
Add basic Vite setup with Three.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fireworks Simulator</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+            height: 100%;
+        }
+        canvas {
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    <canvas class="webgl"></canvas>
+    <script type="module" src="/src/app/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fireworks-simulator",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "three": "^0.160.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0"
+  }
+}

--- a/src/app/World.js
+++ b/src/app/World.js
@@ -1,0 +1,21 @@
+import * as THREE from 'three';
+
+export default class World {
+  constructor({ scene }) {
+    this.scene = scene;
+
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshBasicMaterial({ color: 0xff0000, wireframe: true });
+    this.cube = new THREE.Mesh(geometry, material);
+    this.scene.add(this.cube);
+  }
+
+  update() {
+    this.cube.rotation.x += 0.01;
+    this.cube.rotation.y += 0.01;
+  }
+
+  onResize() {
+    // placeholder for resize logic
+  }
+}

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import World from './World.js';
+
+const canvas = document.querySelector('canvas.webgl');
+
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+const scene = new THREE.Scene();
+
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  100
+);
+scene.add(camera);
+camera.position.set(0, 0, 5);
+
+const world = new World({ scene, camera, renderer });
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  if (typeof world.onResize === 'function') {
+    world.onResize();
+  }
+});
+
+function tick() {
+  requestAnimationFrame(tick);
+  if (typeof world.update === 'function') {
+    world.update();
+  }
+  renderer.render(scene, camera);
+}
+
+tick();


### PR DESCRIPTION
## Summary
- implement main entry to create renderer, scene, and camera
- add minimal `World` class
- add canvas and script to `index.html`
- set up Vite config and ignore `node_modules`

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685230737c44832fa0e7cbcf94f7bf1c