### PR TITLE
Refactor to Experience.js architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Fireworks_Simulator_v2
-3D fireworks simulator
+
+This project is a Three.js based fireworks simulator. The code is structured around an **Experience** class which manages the renderer, camera, and other components. The key folders are:
+
+- `src/app` – entry point (`main.js`) and world setup (`World.js`).
+- `src/experience` – shared 3D experience classes (`Experience.js`, `Controls.js`, `Environment.js`, `PostProcessing.js`).
+- `src/fireworks` – logic specific to the fireworks simulation.
+- `src/particles` – simple GPU‑less particle system with shader placeholders.
+- `src/utils` – utilities for resize and timing events.
+
+Use `npm run dev` to start the Vite development server or `npm run build` to create a production build.

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,41 +1,6 @@
-import * as THREE from 'three';
-import World from './World.js';
+import Experience from '../experience/Experience.js';
 
 const canvas = document.querySelector('canvas.webgl');
 
-const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-renderer.setSize(window.innerWidth, window.innerHeight);
-renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-
-const scene = new THREE.Scene();
-
-const camera = new THREE.PerspectiveCamera(
-  75,
-  window.innerWidth / window.innerHeight,
-  0.1,
-  100
-);
-scene.add(camera);
-camera.position.set(0, 0, 5);
-
-const world = new World({ scene, camera, renderer });
-
-window.addEventListener('resize', () => {
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-  if (typeof world.onResize === 'function') {
-    world.onResize();
-  }
-});
-
-function tick() {
-  requestAnimationFrame(tick);
-  if (typeof world.update === 'function') {
-    world.update();
-  }
-  renderer.render(scene, camera);
-}
-
-tick();
+// eslint-disable-next-line no-unused-vars
+const experience = new Experience(canvas);

--- a/src/experience/Controls.js
+++ b/src/experience/Controls.js
@@ -1,0 +1,12 @@
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+export default class Controls {
+  constructor(camera, canvas) {
+    this.controls = new OrbitControls(camera, canvas);
+    this.controls.enableDamping = true;
+  }
+
+  update() {
+    this.controls.update();
+  }
+}

--- a/src/experience/Environment.js
+++ b/src/experience/Environment.js
@@ -1,0 +1,12 @@
+import * as THREE from 'three';
+
+export default class Environment {
+  constructor(scene) {
+    const ambient = new THREE.AmbientLight(0xffffff, 0.5);
+    scene.add(ambient);
+
+    const directional = new THREE.DirectionalLight(0xffffff, 1);
+    directional.position.set(5, 5, 5);
+    scene.add(directional);
+  }
+}

--- a/src/experience/Experience.js
+++ b/src/experience/Experience.js
@@ -1,0 +1,59 @@
+import * as THREE from 'three';
+import World from '../app/World.js';
+import Sizes from '../utils/Sizes.js';
+import Time from '../utils/Time.js';
+import Controls from './Controls.js';
+import Environment from './Environment.js';
+import PostProcessing from './PostProcessing.js';
+
+let instance = null;
+
+export default class Experience {
+  constructor(canvas) {
+    if (instance) return instance;
+    instance = this;
+
+    // Setup
+    this.canvas = canvas;
+    this.sizes = new Sizes();
+    this.time = new Time();
+    this.scene = new THREE.Scene();
+
+    this.camera = new THREE.PerspectiveCamera(
+      75,
+      this.sizes.width / this.sizes.height,
+      0.1,
+      100
+    );
+    this.camera.position.set(0, 0, 5);
+    this.scene.add(this.camera);
+
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.renderer.setSize(this.sizes.width, this.sizes.height);
+    this.renderer.setPixelRatio(this.sizes.pixelRatio);
+
+    // Components
+    this.controls = new Controls(this.camera, canvas);
+    this.environment = new Environment(this.scene);
+    this.post = new PostProcessing(this.renderer, this.scene, this.camera);
+    this.world = new World({ scene: this.scene });
+
+    // Resize event
+    this.sizes.on('resize', () => {
+      this.camera.aspect = this.sizes.width / this.sizes.height;
+      this.camera.updateProjectionMatrix();
+      this.renderer.setSize(this.sizes.width, this.sizes.height);
+      this.renderer.setPixelRatio(this.sizes.pixelRatio);
+      if (this.post.onResize) this.post.onResize(this.sizes);
+      if (this.world.onResize) this.world.onResize();
+    });
+
+    // Tick event
+    this.time.on('tick', () => {
+      if (this.controls.update) this.controls.update();
+      if (this.world.update) this.world.update(this.time.delta / 1000);
+      if (this.post.update) this.post.update();
+      this.renderer.render(this.scene, this.camera);
+    });
+  }
+}

--- a/src/experience/PostProcessing.js
+++ b/src/experience/PostProcessing.js
@@ -1,0 +1,18 @@
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+
+export default class PostProcessing {
+  constructor(renderer, scene, camera) {
+    this.composer = new EffectComposer(renderer);
+    this.composer.addPass(new RenderPass(scene, camera));
+  }
+
+  onResize(sizes) {
+    this.composer.setSize(sizes.width, sizes.height);
+    this.composer.setPixelRatio(sizes.pixelRatio);
+  }
+
+  update() {
+    this.composer.render();
+  }
+}

--- a/src/particles/shaders/particles.fragment.glsl
+++ b/src/particles/shaders/particles.fragment.glsl
@@ -1,0 +1,1 @@
+// fragment shader placeholder

--- a/src/particles/shaders/particles.vertex.glsl
+++ b/src/particles/shaders/particles.vertex.glsl
@@ -1,0 +1,1 @@
+// vertex shader placeholder

--- a/src/utils/EventEmitter.js
+++ b/src/utils/EventEmitter.js
@@ -1,0 +1,23 @@
+export default class EventEmitter {
+  constructor() {
+    this.listeners = {};
+  }
+
+  on(event, fn) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(fn);
+  }
+
+  off(event, fn) {
+    if (!this.listeners[event]) return;
+    const index = this.listeners[event].indexOf(fn);
+    if (index !== -1) this.listeners[event].splice(index, 1);
+  }
+
+  emit(event, ...args) {
+    if (!this.listeners[event]) return;
+    for (const fn of [...this.listeners[event]]) {
+      fn(...args);
+    }
+  }
+}

--- a/src/utils/Sizes.js
+++ b/src/utils/Sizes.js
@@ -1,0 +1,18 @@
+import EventEmitter from './EventEmitter.js';
+
+export default class Sizes extends EventEmitter {
+  constructor() {
+    super();
+
+    this.width = window.innerWidth;
+    this.height = window.innerHeight;
+    this.pixelRatio = Math.min(window.devicePixelRatio, 2);
+
+    window.addEventListener('resize', () => {
+      this.width = window.innerWidth;
+      this.height = window.innerHeight;
+      this.pixelRatio = Math.min(window.devicePixelRatio, 2);
+      this.emit('resize');
+    });
+  }
+}

--- a/src/utils/Time.js
+++ b/src/utils/Time.js
@@ -1,0 +1,22 @@
+import EventEmitter from './EventEmitter.js';
+
+export default class Time extends EventEmitter {
+  constructor() {
+    super();
+    this.start = performance.now();
+    this.current = this.start;
+    this.delta = 16;
+    this.elapsed = 0;
+
+    const tick = () => {
+      const current = performance.now();
+      this.delta = current - this.current;
+      this.current = current;
+      this.elapsed = this.current - this.start;
+      this.emit('tick');
+      requestAnimationFrame(tick);
+    };
+
+    requestAnimationFrame(tick);
+  }
+}


### PR DESCRIPTION
## Summary
- implement an Experience class and related components
- refactor `main.js` to use Experience
- add simple utilities (event emitter, sizes, time)
- add placeholder shaders and update README with architecture overview

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537ec6bc38832f8a17c66f2f799990