### PR TITLE
Improve particle materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Fireworks_Simulator_v2
 3D fireworks simulator
+
+## Features
+
+- Particle explosions use **additive blending** for brighter colors
+- A smoke texture is applied to particles to give explosions a softer look

--- a/src/particles/ParticleSystem.js
+++ b/src/particles/ParticleSystem.js
@@ -8,6 +8,9 @@ export default class ParticleSystem {
   constructor(scene) {
     this.scene = scene;
     this.particles = [];
+    // Preload the particle texture located in the public folder
+    const loader = new THREE.TextureLoader();
+    this.texture = loader.load('/textures/smoke.png');
   }
 
   /**
@@ -18,10 +21,16 @@ export default class ParticleSystem {
    */
   spawn(position, color, count = 30) {
     for (let i = 0; i < count; i++) {
-      const geometry = new THREE.SphereGeometry(0.02, 4, 4);
-      const material = new THREE.MeshBasicMaterial({ color });
-      const mesh = new THREE.Mesh(geometry, material);
-      mesh.position.copy(position);
+      const material = new THREE.SpriteMaterial({
+        map: this.texture,
+        color,
+        blending: THREE.AdditiveBlending,
+        transparent: true,
+        depthWrite: false,
+      });
+      const sprite = new THREE.Sprite(material);
+      sprite.position.copy(position);
+      sprite.scale.setScalar(0.2);
 
       const velocity = new THREE.Vector3(
         (Math.random() - 0.5) * 6,
@@ -29,8 +38,8 @@ export default class ParticleSystem {
         (Math.random() - 0.5) * 6
       );
 
-      this.scene.add(mesh);
-      this.particles.push({ mesh, velocity, life: 2 });
+      this.scene.add(sprite);
+      this.particles.push({ mesh: sprite, velocity, life: 2 });
     }
   }
 


### PR DESCRIPTION
## Summary
- use SpriteMaterial with AdditiveBlending for fireworks particles
- preload smoke texture for sprites
- document additive blending in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68537ee50638832fa0580aff4684f09b